### PR TITLE
Change transaction list status default

### DIFF
--- a/cmd_query_multisig_transaction_list.go
+++ b/cmd_query_multisig_transaction_list.go
@@ -18,7 +18,7 @@ func (cmd *cmdQueryMultiSigTransactionList) Setup(params clingy.Parameters) {
 	cmd.caller.setup(params)
 	cmd.pending = toggleFlag(params, "pending", "List pending transactions", true)
 	cmd.executed = toggleFlag(params, "executed", "List executed transactions", false)
-	cmd.status = boolFlag(params, "status", "Show the transaction status")
+	cmd.status = !boolFlag(params, "short", "Only show transaction numbers")
 }
 
 func (cmd *cmdQueryMultiSigTransactionList) Execute(ctx context.Context) error {

--- a/cmd_query_multisig_transaction_list_test.go
+++ b/cmd_query_multisig_transaction_list_test.go
@@ -45,16 +45,16 @@ func TestQueryMultiSigTransactionListCmd(t *testing.T) {
 		return requireCmdSuccess(t, harness, append(args, flags...)...)
 	}
 
-	assert.Empty(t, list("--pending=false", "--executed=false"))
-	assert.Empty(t, list("--pending=false", "--executed=true"))
-	assert.Equal(t, "0\n", list("--pending=true", "--executed=false"))
-	assert.Equal(t, expectedPending, list("--pending=true", "--executed=false", "--status"))
+	assert.Empty(t, list("--pending=false", "--executed=false", "--short"))
+	assert.Empty(t, list("--pending=false", "--executed=true", "--short"))
+	assert.Equal(t, "0\n", list("--pending=true", "--executed=false", "--short"))
+	assert.Equal(t, expectedPending, list("--pending=true", "--executed=false"))
 
 	// Now confirm the transaction and assert that it shows up under executed.
 	harness.MultiSig.ConfirmTransaction(t, test.AccountKey[1], transactionID)
 
-	assert.Empty(t, list("--pending=false", "--executed=false"))
-	assert.Empty(t, list("--pending=true", "--executed=false"))
-	assert.Equal(t, "0\n", list("--pending=false", "--executed=true"))
-	assert.Equal(t, expectedExecuted, list("--pending=false", "--executed=true", "--status"))
+	assert.Empty(t, list("--pending=false", "--executed=false", "--short"))
+	assert.Empty(t, list("--pending=true", "--executed=false", "--short"))
+	assert.Equal(t, "0\n", list("--pending=false", "--executed=true", "--short"))
+	assert.Equal(t, expectedExecuted, list("--pending=false", "--executed=true"))
 }

--- a/params.go
+++ b/params.go
@@ -49,7 +49,7 @@ func repeatedAddressArg(params clingy.Parameters, name, desc string) []common.Ad
 }
 
 func toggleFlag(params clingy.Parameters, name, desc string, def bool) bool {
-	return params.Flag(name, desc, def, clingy.Transform(strconv.ParseBool)).(bool)
+	return params.Flag(name, desc, def, clingy.Transform(strconv.ParseBool), clingy.Boolean).(bool)
 }
 
 func boolFlag(params clingy.Parameters, name, desc string) bool {


### PR DESCRIPTION
Just showing transaction numbers is still useful, but this change makes the more common calling convention the default.