### PR TITLE
Make zero confirmation skipping optional and support showing last n transactions

### DIFF
--- a/cmd_query_multisig_transaction_list.go
+++ b/cmd_query_multisig_transaction_list.go
@@ -10,10 +10,10 @@ import (
 type cmdQueryMultiSigTransactionList struct {
 	caller           depMultiSigCaller
 	skipZeroConfirms bool
-	tail     int
-	pending  bool
-	executed bool
-	status   bool
+	tail             int
+	pending          bool
+	executed         bool
+	status           bool
 }
 
 func (cmd *cmdQueryMultiSigTransactionList) Setup(params clingy.Parameters) {
@@ -38,11 +38,9 @@ func (cmd *cmdQueryMultiSigTransactionList) Execute(ctx context.Context) error {
 
 	needsSeparator := false
 
-	if cmd.tail > 0 && len(transactionIDs) > cmd.tail {
-		transactionIDs = transactionIDs[len(transactionIDs)-cmd.tail:]
-	}
-
-	for _, transactionID := range transactionIDs {
+	var transactionIDsToShow []uint64
+	for i := len(transactionIDs) - 1; i >= 0; i-- {
+		transactionID := transactionIDs[i]
 		if cmd.skipZeroConfirms {
 			confirmations, err := caller.GetTransactionConfirmations(ctx, transactionID)
 			if err != nil {
@@ -52,6 +50,14 @@ func (cmd *cmdQueryMultiSigTransactionList) Execute(ctx context.Context) error {
 				continue
 			}
 		}
+		transactionIDsToShow = append(transactionIDsToShow, transactionID)
+		if cmd.tail > 0 && len(transactionIDsToShow) >= cmd.tail {
+			break
+		}
+	}
+
+	for i := len(transactionIDsToShow) - 1; i >= 0; i-- {
+		transactionID := transactionIDsToShow[i]
 
 		if !cmd.status {
 			fmt.Fprintln(clingy.Stdout(ctx), transactionID)

--- a/params.go
+++ b/params.go
@@ -102,6 +102,10 @@ func optionalBigIntEnvFlag(params clingy.Parameters, name, desc string, def *big
 	return params.Flag(name, desc, def, clingy.Getenv(env), clingy.Transform(transformBigInt)).(*big.Int)
 }
 
+func optionalIntFlag(params clingy.Parameters, name, desc string, def int) int {
+	return params.Flag(name, desc, def, clingy.Transform(strconv.Atoi)).(int)
+}
+
 //lint:ignore U1000, utility func that is fine to be unused
 func requiredBigIntEnvFlag(params clingy.Parameters, name, desc string, env string) *big.Int {
 	return params.Flag(name, desc, clingy.Required, clingy.Getenv(env), clingy.Transform(transformBigInt)).(*big.Int)


### PR DESCRIPTION
A previous change filtered out zero confirmation transactions unconditionally. Maybe you want to show them sometimes?

Also, support showing the last n transactions. Perhaps you want the status on the most recent 10 without the status on everything.